### PR TITLE
Add sourcemaps support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ var combineMq = require('gulp-combine-mq');
 gulp.task('combineMq', function () {
 	return gulp.src('test.css')
 	.pipe(combineMq({
-		beautify: false
+		beautify: false,
+		sourcemaps: true
 	}))
 	.pipe(gulp.dest('tmp'));
 });

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ fs = require('graceful-fs'),
 gutil = require('gulp-util'),
 map = require('map-stream'),
 tempWrite = require('temp-write'),
-combineMq = require('combine-mq');
+combineMq = require('combine-mq'),
+applySourceMap = require('vinyl-sourcemaps-apply');
 
 
 module.exports = function (options) {
@@ -46,6 +47,10 @@ module.exports = function (options) {
 					}
 
 					file.contents = new Buffer(processed);
+
+					if(options.sourcemaps) {
+						applySourceMap(file, processed.map);
+					}
 
 					cb(null, file);
 				});

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
 		"map-stream": "^0.1.0",
 		"path": "^0.4.9",
 		"temp-write": "^1.1.0",
-		"through2": "*"
+		"through2": "*",
+		"vinyl-sourcemaps-apply": "~0.1.0"
 	},
 	"devDependencies": {
 		"coveralls": "*",


### PR DESCRIPTION
Under the `sourcemaps: true` option, enable vinyl sourcemap support.